### PR TITLE
Fix middleware matcher for PDF static assets

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -40,5 +40,5 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   // Matcher ignoring `/_next/` and `/api/`
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|og.jpg|genevieve_perron_migneron_en.pdf|genevieve_perron_migneron_fr.pdf).*)']
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|og.jpg|genevieve_perron-migneron_en.pdf|genevieve_perron-migneron_fr.pdf).*)']
 }


### PR DESCRIPTION
### Motivation
- The locale middleware was intercepting requests for the resume PDFs because the matcher used the wrong filename pattern (underscores) so the hyphenated static files were treated as app routes and returned 500s.

### Description
- Update `src/middleware.ts` matcher to exclude `genevieve_perron-migneron_en.pdf` and `genevieve_perron-migneron_fr.pdf` so those files are served as static assets instead of being handled by the locale middleware.

### Testing
- Ran `npm run -s lint` which completed with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc11f491d88325bf1fd8a752f59508)