### PR TITLE
Add GA4 scripts to localized RootLayout with env guard

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from "@vercel/speed-insights/next"
 
@@ -30,12 +31,31 @@ export default function RootLayout({
   children: React.ReactNode
   params: { lang: Locale }
 }) {
+  const gaId = process.env.NEXT_PUBLIC_GA_ID
+
   return (
     <html lang={params.lang}>
       <body className="flex items-center justify-center h-screen font-sans">
         <BackgroundImages />
         <SocialMediaLinks />
         {children}
+
+        {gaId ? (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+              strategy="afterInteractive"
+            />
+            <Script id="ga4-init" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${gaId}');
+              `}
+            </Script>
+          </>
+        ) : null}
         <Analytics />
         <SpeedInsights />
       </body>


### PR DESCRIPTION
### Motivation
- Ensure Google Analytics 4 is loaded once for all language routes by injecting GA scripts into the localized root layout.
- Avoid double-counting pageviews by verifying there are no other GA/gtag injections under `src/app`.
- Remove the hard-coded GA ID by using an environment variable for safer configuration and easier ops.

### Description
- Import `Script` from `next/script` in `src/app/[lang]/layout.tsx` and add a `const gaId = process.env.NEXT_PUBLIC_GA_ID` guard. 
- Inject the external GA4 loader script `https://www.googletagmanager.com/gtag/js?id=${gaId}` with `strategy="afterInteractive"` and an inline init script that sets `window.dataLayer`, `gtag()`, and calls `gtag('config', gaId)` when `gaId` is present. 
- Place the scripts near the end of the `<body>` alongside (and before) the existing `<Analytics />` and `<SpeedInsights />` components so existing analytics remain intact. 
- Use the `NEXT_PUBLIC_GA_ID` environment variable instead of a hard-coded tracking ID and render nothing when the variable is not set. 

### Testing
- Ran `rg -n "gtag|googletagmanager|G-QGDBCZYG6K|NEXT_PUBLIC_GA_ID" src/app` to verify there are no duplicate GA/gtag injections, and the check succeeded. 
- No automated test suite was run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39566ce1c832591bd6cda34538c83)