### PR TITLE
Add cookie consent UI, privacy & cookie policy pages, and GA consent-aware integration

### DIFF
--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -21,5 +21,53 @@
       "fields": "All fields are required."
     },
     "thankyou": "Thanks a bunch for contacting me! Your message has been beamed directly into my digital lair."
+  },
+  "cookieBanner": {
+    "title": "Cookie preferences",
+    "description": "We use cookies and similar technologies to run this website and measure traffic with Google Analytics. You can accept or refuse non-essential analytics cookies.",
+    "accept": "Accept analytics",
+    "reject": "Reject analytics",
+    "privacy": "Privacy policy",
+    "cookies": "Cookie policy"
+  },
+  "privacyPolicy": {
+    "title": "Privacy Policy",
+    "updated": "Last updated: April 30, 2026",
+    "intro": "This policy explains how personal information is handled on this website in compliance with Quebec Law 25.",
+    "sections": [
+      {
+        "title": "What we collect",
+        "text": "When you use the contact form, we collect the information you submit (name, email, subject, and message). We also collect aggregate website usage information through Google Analytics if you consent."
+      },
+      {
+        "title": "Why we collect it",
+        "text": "Contact form data is used only to respond to your request. Analytics data is used to understand website traffic and improve content."
+      },
+      {
+        "title": "Consent and cookies",
+        "text": "Non-essential analytics cookies are loaded only after explicit consent via the cookie banner. You can refuse analytics cookies without affecting core website access."
+      },
+      {
+        "title": "Retention and protection",
+        "text": "Personal information is retained only as long as necessary for the stated purpose and is protected with reasonable security measures."
+      },
+      {
+        "title": "Your rights",
+        "text": "You may request access, correction, or deletion of your personal information, subject to applicable legal requirements."
+      }
+    ],
+    "contact": "For privacy requests, use the contact page.",
+    "home": "Back to home"
+  },
+  "cookiePolicy": {
+    "title": "Cookie Policy",
+    "updated": "Last updated: April 30, 2026",
+    "intro": "This page explains how cookies are used on this website.",
+    "cookies": [
+      "Essential cookies: required for core website functionality.",
+      "Analytics cookies (Google Analytics): used only with your consent to measure visits and interactions."
+    ],
+    "rights": "You can accept or reject analytics cookies using the cookie banner. If you previously consented, you can clear your browser storage to reset your choice.",
+    "home": "Back to home"
   }
 }

--- a/dictionaries/fr.json
+++ b/dictionaries/fr.json
@@ -21,5 +21,53 @@
       "fields": "Remplir tous les champs"
     },
     "thankyou": "Merci beaucoup de m'avoir contacté ! Votre message a été transmis."
+  },
+  "cookieBanner": {
+    "title": "Préférences de témoins",
+    "description": "Nous utilisons des témoins et technologies similaires pour faire fonctionner ce site et mesurer l'audience avec Google Analytics. Vous pouvez accepter ou refuser les témoins analytiques non essentiels.",
+    "accept": "Accepter les témoins analytiques",
+    "reject": "Refuser les témoins analytiques",
+    "privacy": "Politique de confidentialité",
+    "cookies": "Politique de témoins"
+  },
+  "privacyPolicy": {
+    "title": "Politique de confidentialité",
+    "updated": "Dernière mise à jour : 30 avril 2026",
+    "intro": "Cette politique explique la gestion des renseignements personnels sur ce site conformément à la Loi 25 du Québec.",
+    "sections": [
+      {
+        "title": "Renseignements collectés",
+        "text": "Lorsque vous utilisez le formulaire de contact, nous recueillons les informations soumises (nom, courriel, sujet et message). Nous recueillons aussi des données d’audience agrégées via Google Analytics si vous y consentez."
+      },
+      {
+        "title": "Pourquoi nous les recueillons",
+        "text": "Les données du formulaire servent uniquement à répondre à votre demande. Les données analytiques servent à comprendre le trafic et améliorer le contenu."
+      },
+      {
+        "title": "Consentement et témoins",
+        "text": "Les témoins analytiques non essentiels sont activés seulement après un consentement explicite dans la bannière. Vous pouvez refuser ces témoins sans impact sur l’accès au site."
+      },
+      {
+        "title": "Conservation et protection",
+        "text": "Les renseignements personnels sont conservés seulement pour la durée nécessaire aux fins prévues et protégés par des mesures de sécurité raisonnables."
+      },
+      {
+        "title": "Vos droits",
+        "text": "Vous pouvez demander l’accès, la rectification ou la suppression de vos renseignements personnels, sous réserve des exigences légales applicables."
+      }
+    ],
+    "contact": "Pour toute demande liée à la vie privée, utilisez la page contact.",
+    "home": "Retour à l’accueil"
+  },
+  "cookiePolicy": {
+    "title": "Politique de témoins",
+    "updated": "Dernière mise à jour : 30 avril 2026",
+    "intro": "Cette page explique comment les témoins sont utilisés sur ce site.",
+    "cookies": [
+      "Témoins essentiels : requis pour les fonctions de base du site.",
+      "Témoins analytiques (Google Analytics) : utilisés seulement avec votre consentement pour mesurer les visites et les interactions."
+    ],
+    "rights": "Vous pouvez accepter ou refuser les témoins analytiques via la bannière. Si vous avez déjà consenti, vous pouvez supprimer le stockage du navigateur pour réinitialiser votre choix.",
+    "home": "Retour à l’accueil"
   }
 }

--- a/src/app/[lang]/cookie-policy/page.tsx
+++ b/src/app/[lang]/cookie-policy/page.tsx
@@ -7,15 +7,15 @@ export default async function CookiePolicyPage({ params: { lang } }: { params: {
 
   return (
     <main className="policy-page">
-      <h1>{cookiePolicy.title}</h1>
-      <p>{cookiePolicy.updated}</p>
-      <p>{cookiePolicy.intro}</p>
-      <ul>
+      <h1 className="intro-title text-xl md:text-xl font-bold mb-2"><span>_</span>{cookiePolicy.title}</h1>
+      <p className="text-sm mb-2">{cookiePolicy.updated}</p>
+      <p className="text-sm mb-2">{cookiePolicy.intro}</p>
+      <ul className="ml-2">
         {cookiePolicy.cookies.map(item => (
-          <li key={item}>{item}</li>
+          <li className="text-sm mb-2" key={item}>{item}</li>
         ))}
       </ul>
-      <p>{cookiePolicy.rights}</p>
+      <p className="text-sm mb-2">{cookiePolicy.rights}</p>
       <Link className="button" href={lang === 'en' ? '/' : `/${lang}`}>
         <span>{cookiePolicy.home}</span>
       </Link>

--- a/src/app/[lang]/cookie-policy/page.tsx
+++ b/src/app/[lang]/cookie-policy/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+import { getDictionary } from '@/lib/dictionary'
+import { Locale } from '../../../../i18n-config'
+
+export default async function CookiePolicyPage({ params: { lang } }: { params: { lang: Locale } }) {
+  const { cookiePolicy } = await getDictionary(lang)
+
+  return (
+    <main className="policy-page">
+      <h1>{cookiePolicy.title}</h1>
+      <p>{cookiePolicy.updated}</p>
+      <p>{cookiePolicy.intro}</p>
+      <ul>
+        {cookiePolicy.cookies.map(item => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      <p>{cookiePolicy.rights}</p>
+      <Link className="button" href={lang === 'en' ? '/' : `/${lang}`}>
+        <span>{cookiePolicy.home}</span>
+      </Link>
+    </main>
+  )
+}

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import Script from 'next/script'
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from "@vercel/speed-insights/next"
 
@@ -8,6 +7,9 @@ import { Locale, i18n } from '../../../i18n-config';
 import './../styles/index.scss'
 import SocialMediaLinks from '../../components/SocialMediaLinks';
 import BackgroundImages from '../../components/BackgroundImage';
+import CookieBanner from '@/components/CookieBanner';
+import GoogleAnalytics from '@/components/GoogleAnalytics';
+import { getDictionary } from '@/lib/dictionary';
 
 export const metadata: Metadata = {
   title: 'Genevieve Perron Migneron - Portfolio',
@@ -24,7 +26,7 @@ export async function generateStaticParams() {
   return i18n.locales.map(locale => ({ lang: locale }))
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
   params
 }: {
@@ -32,6 +34,7 @@ export default function RootLayout({
   params: { lang: Locale }
 }) {
   const gaId = process.env.NEXT_PUBLIC_GA_ID
+  const { cookieBanner } = await getDictionary(params.lang)
 
   return (
     <html lang={params.lang}>
@@ -40,22 +43,8 @@ export default function RootLayout({
         <SocialMediaLinks />
         {children}
 
-        {gaId ? (
-          <>
-            <Script
-              src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
-              strategy="afterInteractive"
-            />
-            <Script id="ga4-init" strategy="afterInteractive">
-              {`
-                window.dataLayer = window.dataLayer || [];
-                function gtag(){dataLayer.push(arguments);}
-                gtag('js', new Date());
-                gtag('config', '${gaId}');
-              `}
-            </Script>
-          </>
-        ) : null}
+        <CookieBanner lang={params.lang} content={cookieBanner} />
+        {gaId ? <GoogleAnalytics gaId={gaId} /> : null}
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/app/[lang]/privacy-policy/page.tsx
+++ b/src/app/[lang]/privacy-policy/page.tsx
@@ -7,16 +7,16 @@ export default async function PrivacyPolicyPage({ params: { lang } }: { params: 
 
   return (
     <main className="policy-page">
-      <h1>{privacyPolicy.title}</h1>
-      <p>{privacyPolicy.updated}</p>
-      <p>{privacyPolicy.intro}</p>
+      <h1 className="intro-title md:text-xl font-bold mb-2"><span>_</span>{privacyPolicy.title}</h1>
+      <p className="text-sm mb-2">{privacyPolicy.updated}</p>
+      <p className="text-xs mb-2">{privacyPolicy.intro}</p>
       {privacyPolicy.sections.map(section => (
         <section key={section.title}>
-          <h2>{section.title}</h2>
-          <p>{section.text}</p>
+          <h2 className="text-md font-bold">{section.title}</h2>
+          <p className="text-xs mb-2">{section.text}</p>
         </section>
       ))}
-      <p>{privacyPolicy.contact}</p>
+      <p className="d-block text-xs mt-4 mb-4">{privacyPolicy.contact}</p>
       <Link className="button" href={lang === 'en' ? '/' : `/${lang}`}>
         <span>{privacyPolicy.home}</span>
       </Link>

--- a/src/app/[lang]/privacy-policy/page.tsx
+++ b/src/app/[lang]/privacy-policy/page.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { getDictionary } from '@/lib/dictionary'
+import { Locale } from '../../../../i18n-config'
+
+export default async function PrivacyPolicyPage({ params: { lang } }: { params: { lang: Locale } }) {
+  const { privacyPolicy } = await getDictionary(lang)
+
+  return (
+    <main className="policy-page">
+      <h1>{privacyPolicy.title}</h1>
+      <p>{privacyPolicy.updated}</p>
+      <p>{privacyPolicy.intro}</p>
+      {privacyPolicy.sections.map(section => (
+        <section key={section.title}>
+          <h2>{section.title}</h2>
+          <p>{section.text}</p>
+        </section>
+      ))}
+      <p>{privacyPolicy.contact}</p>
+      <Link className="button" href={lang === 'en' ? '/' : `/${lang}`}>
+        <span>{privacyPolicy.home}</span>
+      </Link>
+    </main>
+  )
+}

--- a/src/app/styles/_cookie-banner.scss
+++ b/src/app/styles/_cookie-banner.scss
@@ -1,0 +1,52 @@
+.cookie-banner {
+  position: fixed;
+  left: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  background: rgba(13, 13, 13, 0.95);
+  border: 1px solid #777;
+  border-radius: 12px;
+  padding: 1rem;
+  max-width: 720px;
+  margin: 0 auto;
+
+  h2 {
+    font-size: 1.15rem;
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    margin-bottom: 0.75rem;
+  }
+
+  &-links {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+
+    a {
+      text-decoration: underline;
+    }
+  }
+
+  &-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+}
+
+.policy-page {
+  width: min(900px, 90%);
+  margin: 4rem auto;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid #777;
+  border-radius: 12px;
+  padding: 2rem;
+
+  h1 { margin-bottom: 1rem; }
+  h2 { margin: 1rem 0 0.5rem; }
+  p, li { line-height: 1.6; }
+  ul { list-style: disc; padding-left: 1.25rem; margin-bottom: 1rem; }
+}

--- a/src/app/styles/_cookie-banner.scss
+++ b/src/app/styles/_cookie-banner.scss
@@ -1,31 +1,34 @@
 .cookie-banner {
   position: fixed;
-  left: 1rem;
-  right: 1rem;
-  bottom: 1rem;
+  left: 16px;
+  right: 16px;
+  bottom: 16px;
   z-index: 1000;
-  background: rgba(13, 13, 13, 0.95);
+  background: rgba(13, 13, 13, 0.25);
+  backdrop-filter: blur(10px);
   border: 1px solid #777;
   border-radius: 12px;
-  padding: 1rem;
+  padding: 16px;
   max-width: 720px;
   margin: 0 auto;
-
+  color: #ffffff;
   h2 {
-    font-size: 1.15rem;
-    margin-bottom: 0.5rem;
+    font-size: 14px;
+    margin-bottom: 8px;
   }
 
   p {
-    margin-bottom: 0.75rem;
+    margin-bottom: 10px;
+    font-size: 10px;
   }
 
   &-links {
     display: flex;
-    gap: 1rem;
-    margin-bottom: 0.75rem;
+    gap: 16px;
+    margin-bottom: 12px;
 
     a {
+      font-size: 12px;
       text-decoration: underline;
     }
   }
@@ -33,20 +36,10 @@
   &-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 12px;
+    button {
+      position: relative;
+    }
   }
 }
 
-.policy-page {
-  width: min(900px, 90%);
-  margin: 4rem auto;
-  background: rgba(0, 0, 0, 0.5);
-  border: 1px solid #777;
-  border-radius: 12px;
-  padding: 2rem;
-
-  h1 { margin-bottom: 1rem; }
-  h2 { margin: 1rem 0 0.5rem; }
-  p, li { line-height: 1.6; }
-  ul { list-style: disc; padding-left: 1.25rem; margin-bottom: 1rem; }
-}

--- a/src/app/styles/_cookie-banner.scss
+++ b/src/app/styles/_cookie-banner.scss
@@ -43,3 +43,31 @@
   }
 }
 
+.cookie-banner-tab {
+  position: fixed;
+  left: 20px;
+  bottom: 20px;
+  z-index: 999;
+  width: 48px;
+  height: 48px;
+  background: rgba(13, 13, 13, 0.25);
+  backdrop-filter: blur(10px);
+  border-radius: 12px;
+  font-size: 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  padding: 0;
+
+  &:hover {
+    background: rgba(13, 13, 13, 0.4);
+    transform: scale(1.1);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+

--- a/src/app/styles/_policy.scss
+++ b/src/app/styles/_policy.scss
@@ -1,0 +1,28 @@
+.policy-page {
+  color: #ffffff;
+  width: min(800px, 90%);
+  margin: 64px auto;
+  background: rgba(13, 13, 13, 0.25);
+  backdrop-filter: blur(10px);
+  border-radius: 12px;
+  padding: 32px;
+
+  h1 {
+    margin-bottom: 16px;
+  }
+
+  h2 {
+    margin: 16px 0 8px;
+  }
+
+  p,
+  li {
+    line-height: 1;
+  }
+
+  ul {
+    list-style: disc;
+    padding-left: 12px;
+    margin-bottom: 16px;
+  }
+}

--- a/src/app/styles/index.scss
+++ b/src/app/styles/index.scss
@@ -9,3 +9,5 @@
 @import './intro';
 @import './social-media-icons';
 @import './title';
+
+@import './cookie-banner';

--- a/src/app/styles/index.scss
+++ b/src/app/styles/index.scss
@@ -9,5 +9,6 @@
 @import './intro';
 @import './social-media-icons';
 @import './title';
+@import './policy';
 
 @import './cookie-banner';

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -33,7 +33,34 @@ export default function CookieBanner({ lang, content }: CookieBannerProps) {
     setVisible(false)
   }
 
-  if (!visible) return null
+  const clearAllCookies = () => {
+    document.cookie.split(';').forEach((c) => {
+      const eqPos = c.indexOf('=')
+      const name = eqPos > -1 ? c.substring(0, eqPos).trim() : c.trim()
+      if (name) {
+        document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;`
+        document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;domain=${document.location.hostname};`
+      }
+    })
+  }
+
+  const handleRejectCookies = () => {
+    clearAllCookies()
+    saveConsent('rejected')
+  }
+
+  if (!visible)
+    return (
+      <button
+        type="button"
+        className="cookie-banner-tab"
+        onClick={() => setVisible(true)}
+        aria-label={content.title}
+        title={content.title}
+      >
+        🍪
+      </button>
+    )
 
   return (
     <aside className="cookie-banner" role="dialog" aria-live="polite" aria-label={content.title}>
@@ -47,7 +74,7 @@ export default function CookieBanner({ lang, content }: CookieBannerProps) {
         <button type="button" className="button w-full" onClick={() => saveConsent('accepted')}>
           <span>{content.accept}</span>
         </button>
-        <button type="button" className="button w-full" onClick={() => saveConsent('rejected')}>
+        <button type="button" className="button w-full" onClick={() => handleRejectCookies()}>
           <span>{content.reject}</span>
         </button>
       </div>

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -44,10 +44,10 @@ export default function CookieBanner({ lang, content }: CookieBannerProps) {
         <Link href={lang === 'en' ? '/cookie-policy' : `/${lang}/cookie-policy`}>{content.cookies}</Link>
       </div>
       <div className="cookie-banner-actions">
-        <button type="button" className="button" onClick={() => saveConsent('accepted')}>
+        <button type="button" className="button w-full" onClick={() => saveConsent('accepted')}>
           <span>{content.accept}</span>
         </button>
-        <button type="button" className="button button--outline" onClick={() => saveConsent('rejected')}>
+        <button type="button" className="button w-full" onClick={() => saveConsent('rejected')}>
           <span>{content.reject}</span>
         </button>
       </div>

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+type CookieBannerContent = {
+  title: string
+  description: string
+  accept: string
+  reject: string
+  privacy: string
+  cookies: string
+}
+
+type CookieBannerProps = {
+  lang: 'en' | 'fr'
+  content: CookieBannerContent
+}
+
+const CONSENT_KEY = 'cookie-consent'
+
+export default function CookieBanner({ lang, content }: CookieBannerProps) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const consent = window.localStorage.getItem(CONSENT_KEY)
+    setVisible(!consent)
+  }, [])
+
+  const saveConsent = (value: 'accepted' | 'rejected') => {
+    window.localStorage.setItem(CONSENT_KEY, value)
+    window.dispatchEvent(new Event('cookie-consent-updated'))
+    setVisible(false)
+  }
+
+  if (!visible) return null
+
+  return (
+    <aside className="cookie-banner" role="dialog" aria-live="polite" aria-label={content.title}>
+      <h2>{content.title}</h2>
+      <p>{content.description}</p>
+      <div className="cookie-banner-links">
+        <Link href={lang === 'en' ? '/privacy-policy' : `/${lang}/privacy-policy`}>{content.privacy}</Link>
+        <Link href={lang === 'en' ? '/cookie-policy' : `/${lang}/cookie-policy`}>{content.cookies}</Link>
+      </div>
+      <div className="cookie-banner-actions">
+        <button type="button" className="button" onClick={() => saveConsent('accepted')}>
+          <span>{content.accept}</span>
+        </button>
+        <button type="button" className="button button--outline" onClick={() => saveConsent('rejected')}>
+          <span>{content.reject}</span>
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import Script from 'next/script'
+import { useEffect, useState } from 'react'
+
+type GoogleAnalyticsProps = {
+  gaId: string
+}
+
+export default function GoogleAnalytics({ gaId }: GoogleAnalyticsProps) {
+  const [enabled, setEnabled] = useState(false)
+
+  useEffect(() => {
+    const updateConsent = () => {
+      const consent = window.localStorage.getItem('cookie-consent')
+      setEnabled(consent === 'accepted')
+    }
+
+    updateConsent()
+    window.addEventListener('cookie-consent-updated', updateConsent)
+    window.addEventListener('storage', updateConsent)
+
+    return () => {
+      window.removeEventListener('cookie-consent-updated', updateConsent)
+      window.removeEventListener('storage', updateConsent)
+    }
+  }, [])
+
+  if (!enabled) return null
+
+  return (
+    <>
+      <Script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} strategy="afterInteractive" />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${gaId}', { anonymize_ip: true });
+        `}
+      </Script>
+    </>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide GDPR/Quebec Law 25 compliant cookie consent UX and dedicated policy pages for users to view privacy and cookie details. 
- Prevent loading Google Analytics until the user explicitly accepts analytics cookies and offer an explicit accept/reject choice stored in browser storage.

### Description
- Added localized privacy and cookie policy strings to `dictionaries/en.json` and `dictionaries/fr.json` and included last-updated text and structured sections. 
- Implemented a client `CookieBanner` component that stores consent in `localStorage`, exposes a `cookie-consent-updated` event, and links to `/privacy-policy` and `/cookie-policy` per locale. 
- Implemented a client `GoogleAnalytics` component that conditionally injects GA scripts only when consent is `accepted` and configures GA with `anonymize_ip: true`. 
- Added policy pages at `src/app/[lang]/privacy-policy/page.tsx` and `src/app/[lang]/cookie-policy/page.tsx`, updated `src/app/[lang]/layout.tsx` to include the cookie banner and GA component, and added styles in `_cookie-banner.scss` and imports in `index.scss`.

### Testing
- Performed a production build with `next build` and the build completed successfully. 
- Ran TypeScript checks with `tsc --noEmit` and the type check passed. 
- Ran linting (`npm run lint`) and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39c52f4888325a0625d0e0ce6e3b9)