### PR TITLE
Track GA events for contact form submit outcomes

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { track } from '@vercel/analytics';
 import emailjs from 'emailjs-com';
 
@@ -16,6 +16,17 @@ const ContactForm: React.FC<ContactFormProps> = ({ form }) => {
   const [bamboozled, setBamboozled] = useState<string>('');
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [formSent, setFormSent] = useState<boolean>(false);
+
+  const trackGaEvent = (eventName: string) => {
+    if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+      return;
+    }
+
+    window.gtag('event', eventName, {
+      event_category: 'contact',
+      event_label: 'contact_form',
+    });
+  }
 
   const validateForm = () => {
     if (!name || !subject || !message || !email) {
@@ -57,12 +68,14 @@ const ContactForm: React.FC<ContactFormProps> = ({ form }) => {
       .then((response) => {
         console.log('Email sent successfully:', response);
         track('Email sent');
+        trackGaEvent('contact_form_submit_success');
         setFormSent(true);
         // Handle success
       })
       .catch((error) => {
         console.error('Email send failed:', error);
         track('Email error');
+        trackGaEvent('contact_form_submit_error');
         setError('Failed to send email. Please try again later.');
         // Handle error
       })

--- a/src/types/gtag.d.ts
+++ b/src/types/gtag.d.ts
@@ -1,0 +1,7 @@
+export {}
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+  }
+}


### PR DESCRIPTION
### Motivation
- Record Google Analytics events for contact form submission outcomes so success and failure can be measured.
- Avoid runtime errors when analytics is not present or user consent blocks it by only sending events when `window.gtag` is available.

### Description
- Add a `trackGaEvent` helper in `src/components/ContactForm.tsx` that checks `window.gtag` before calling `gtag` and sets `event_category` and `event_label` metadata.
- Trigger `contact_form_submit_success` on successful email sends and `contact_form_submit_error` on failed sends inside the existing `emailjs.send(...)` flow.
- Remove the unused `useEffect` import from the component.

### Testing
- Ran `npm run lint` and ESLint completed with no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd340f0788325a931fd6462d2f27b)